### PR TITLE
update build to npm ci, no manual option

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,7 +1,8 @@
 name: Deploy SvelteKit to GitHub Pages
 
 on:
-  workflow_dispatch: # allows manual trigger
+  push:
+    branches: [main]
 
 permissions:
   contents: read
@@ -21,9 +22,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: npm # cache node_modules for faster builds
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci # install dependencies using lock file
 
       # Build the SvelteKit project
       - name: Build project

--- a/package-lock.json
+++ b/package-lock.json
@@ -3674,6 +3674,21 @@
                 }
             }
         },
+        "node_modules/svelte-check/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/svelte-eslint-parser": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.0.tgz",


### PR DESCRIPTION
This also finally adds picomatch to the lock file to fix the build (sorry, not sure how I missed this again and again!)